### PR TITLE
サイドバー状態保持と曲詳細ページ追加

### DIFF
--- a/src/main/java/com/github/luluvb0r/nogi_fun_site/controller/CallController.java
+++ b/src/main/java/com/github/luluvb0r/nogi_fun_site/controller/CallController.java
@@ -55,6 +55,28 @@ public class CallController {
     }
 
     /**
+     * 指定されたシングル内の曲詳細を表示する。
+     *
+     * @param number シングルの番号
+     * @param index  曲のインデックス(0始まり)
+     * @param model  曲データを格納するモデル
+     * @return 曲詳細ページのビュー名。不明な場合は曲一覧へリダイレクト
+     */
+    @GetMapping("/calls/{number}/songs/{index}")
+    public String songDetail(@PathVariable int number, @PathVariable int index, Model model) {
+        log.debug("Showing detail for song {} of single {}", index, number);
+        Single single = SingleRepository.findByNumber(number);
+        if (single == null || index < 0 || index >= single.songs().size()) {
+            log.debug("Song {} of single {} not found, redirecting", index, number);
+            return "redirect:/calls/" + number;
+        }
+        String song = single.songs().get(index);
+        model.addAttribute("single", single);
+        model.addAttribute("song", song);
+        return "song";
+    }
+
+    /**
      * JSON形式でシングル一覧を返す。
      *
      * @return シングルのリスト

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -9,8 +9,22 @@ header {
     background-color: #800080;
     color: white;
     padding: 1rem;
-    text-align: center;
     font-size: 1.5rem;
+}
+
+.header-inner {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.home-button {
+    background-color: #fff;
+    color: #800080;
+    padding: 0.3rem 0.6rem;
+    border-radius: 4px;
+    text-decoration: none;
+    font-size: 1rem;
 }
 
 .container {

--- a/src/main/resources/static/js/sidebar.js
+++ b/src/main/resources/static/js/sidebar.js
@@ -19,6 +19,16 @@
     let loading = false; // 取得中か（多重実行防止）
 
     const HIDDEN = 'hidden';
+    const STORAGE_KEY = 'calls-open';
+
+    // 状態を保存する
+    const saveState = (open) => {
+      try {
+        sessionStorage.setItem(STORAGE_KEY, open ? '1' : '0');
+      } catch (e) {
+        console.debug('[sidebar] failed to save state', e);
+      }
+    };
 
     // 表示/非表示と aria を同期させる
     const show = (visible) => {
@@ -70,6 +80,8 @@
 
           loaded = true;
           show(true); // 取得後に開く
+          saveState(true);
+          console.debug('[sidebar] fetched singles and opened list');
         } catch (err) {
           // 失敗時はメッセージを表示（アラートだけだとUXが悪いのでリスト内に表示）
           console.error('[sidebar] /api/singles fetch error:', err);
@@ -78,6 +90,7 @@
           li.textContent = '読み込みに失敗しました。時間をおいて再試行してください。';
           list.appendChild(li);
           show(true);
+          saveState(true);
         } finally {
           loading = false;
         }
@@ -85,7 +98,21 @@
         // 2回目以降は単に開閉
         const willOpen = list.classList.contains(HIDDEN);
         show(willOpen);
+        saveState(willOpen);
+        console.debug(`[sidebar] toggled list ${willOpen ? 'open' : 'close'}`);
       }
     });
+
+    // 保存された状態を復元する
+    let rememberedOpen = false;
+    try {
+      rememberedOpen = sessionStorage.getItem(STORAGE_KEY) === '1';
+    } catch (e) {
+      console.debug('[sidebar] failed to read state', e);
+    }
+    if (rememberedOpen) {
+      console.debug('[sidebar] restoring open state');
+      toggle.click();
+    }
   });
 })();

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,3 +1,6 @@
 <header xmlns:th="http://www.thymeleaf.org" th:fragment="header">
-    乃木坂46のライブをより楽しむためのサイト
+    <div class="header-inner">
+        <span>乃木坂46のライブをより楽しむためのサイト</span>
+        <a href="/" class="home-button">ホームへ戻る</a>
+    </div>
 </header>

--- a/src/main/resources/templates/song.html
+++ b/src/main/resources/templates/song.html
@@ -2,7 +2,7 @@
 <html lang="ja" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title th:text="${single.number} + '枚目シングル ' + ${single.name}">シングル詳細</title>
+    <title th:text="${song}">曲詳細</title>
     <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
@@ -10,12 +10,8 @@
 <div class="container">
     <aside th:replace="fragments/sidebar :: sidebar"></aside>
     <main>
-        <h2 th:text="${single.number} + '枚目シングル ' + ${single.name}"></h2>
-        <ul>
-            <li th:each="song, stat : ${single.songs}">
-                <a th:href="@{'/calls/' + ${single.number} + '/songs/' + ${stat.index}}" th:text="${song}"></a>
-            </li>
-        </ul>
+        <h2 th:text="${song}"></h2>
+        <p>このページは曲の詳細情報を表示します。</p>
     </main>
 </div>
 <div th:replace="fragments/footer :: footer-scripts"></div>


### PR DESCRIPTION
## 概要
- サイドバーの開閉状態をセッション保存してページ遷移後も維持
- 全ページ共通のホームボタンをヘッダーに追加
- 曲名クリックで詳細ページへ遷移する機能を追加

## テスト
- `mvn -q test` (ネットワーク到達不可のため失敗)

------
https://chatgpt.com/codex/tasks/task_e_68a29ea956148326aeea1c61f7c939ec