### PR TITLE
フォーム入力で円タメグラフを生成

### DIFF
--- a/src/main/resources/static/css/entame-graph.css
+++ b/src/main/resources/static/css/entame-graph.css
@@ -1,7 +1,14 @@
 .entame-main { padding: 16px; }
 .toolbar { margin: 12px 0 16px; }
-#entame-generate-btn { padding: 8px 14px; font-size: 14px; border-radius: 10px; border: 1px solid #ccc; cursor: pointer; }
-#entame-generate-btn:hover { opacity: .9; }
+#entame-generate-btn, #entame-add-btn { padding: 8px 14px; font-size: 14px; border-radius: 10px; border: 1px solid #ccc; cursor: pointer; }
+#entame-generate-btn:hover, #entame-add-btn:hover { opacity: .9; }
+
+.form-container { margin: 12px 0; }
+.form-row { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }
+.form-row .label { flex: 1; padding: 4px; }
+.form-row .percent { width: 80px; padding: 4px; }
+.form-row .remove-btn { padding: 4px 8px; }
+.color-chip { width: 24px; height: 24px; border: 1px solid #333; border-radius: 4px; }
 
 
 .entame-stage {

--- a/src/main/resources/static/css/entame-graph.css
+++ b/src/main/resources/static/css/entame-graph.css
@@ -1,7 +1,8 @@
 .entame-main { padding: 16px; }
 .toolbar { margin: 12px 0 16px; }
-#entame-generate-btn, #entame-add-btn { padding: 8px 14px; font-size: 14px; border-radius: 10px; border: 1px solid #ccc; cursor: pointer; }
-#entame-generate-btn:hover, #entame-add-btn:hover { opacity: .9; }
+#entame-generate-btn, #entame-add-btn, #entame-save-btn { padding: 8px 14px; font-size: 14px; border-radius: 10px; border: 1px solid #ccc; cursor: pointer; }
+#entame-generate-btn:hover, #entame-add-btn:hover, #entame-save-btn:hover { opacity: .9; }
+.toolbar button:disabled { opacity: .6; cursor: not-allowed; }
 
 .form-container { margin: 12px 0; }
 .form-row { display: flex; align-items: center; gap: 8px; margin-bottom: 8px; }

--- a/src/main/resources/static/js/entame-graph.js
+++ b/src/main/resources/static/js/entame-graph.js
@@ -1,3 +1,4 @@
+// 円タメグラフのフォーム管理とSVG生成を行うスクリプト
 (() => {
   "use strict";
 
@@ -19,18 +20,15 @@
     LEGEND_RIGHT_PAD: 20,
   };
 
-  /*** データ（必要に応じて編集） ***/
-  const DATA = [
-    { label: "映画『それいけ！アンパンマン 勇気の花がひらくとき』", percent: 25, color: "#D6332F" },
-    { label: "『きらりん☆レボリューション』",                          percent: 15, color: "#F08B2C" },
-    { label: "乃木坂46『シンクロニシティ』",                           percent: 15, color: "#FFB11B" },
-    { label: "カゲロウプロジェクト『カゲロウデイズ』",                  percent: 10, color: "#7DD21E" },
-    { label: "アニメ『僕のヒーローアカデミア』第2話",                    percent: 9,  color: "#28C7B0" },
-    { label: "アニメ『けいおん！』",                                   percent: 8,  color: "#00B3E6" },
-    { label: "SEKAI NO OWARI『幻の命』",                               percent: 7,  color: "#4BA3F6" },
-    { label: "にじさんじ",                                               percent: 6,  color: "#7D4BE3" },
-    { label: "映画『サマーウォーズ』",                                 percent: 5,  color: "#E63B9F" },
+  /*** 色とフォーム上限 ***/
+  const COLORS = [
+    "#D6332F", "#F08B2C", "#FFB11B", "#7DD21E", "#28C7B0",
+    "#00B3E6", "#4BA3F6", "#7D4BE3", "#E63B9F"
   ];
+  const MAX_ITEMS = COLORS.length;
+  const SELECT_OPTIONS = Array.from({ length: 100 }, (_, i) =>
+    `<option value="${i + 1}">${i + 1}</option>`
+  ).join("");
 
   /*** DOM 準備 ***/
   function ready(fn) {
@@ -39,12 +37,18 @@
   }
 
   ready(() => {
+    const $add = document.getElementById("entame-add-btn");
     const $btn = document.getElementById("entame-generate-btn")
               || document.getElementById("entame-generate-btnwo");
+    const $container = document.getElementById("entame-form-container");
     let $stage = document.getElementById("entame-stage");
 
     if (!$btn) {
       console.warn("[entame] ボタンが見つかりません。id='entame-generate-btn' を付けてください。");
+      return;
+    }
+    if (!$add || !$container) {
+      console.warn("[entame] フォーム要素が見つかりません。");
       return;
     }
     if (!$stage) {
@@ -55,11 +59,57 @@
       $btn.insertAdjacentElement("afterend", $stage);
     }
 
+    /** フォーム行の色を順番に設定 */
+    const refreshColors = () => {
+      Array.from($container.children).forEach((row, i) => {
+        const chip = row.querySelector(".color-chip");
+        if (chip) chip.style.backgroundColor = COLORS[i];
+      });
+    };
+
+    /** フォーム行を追加する */
+    const createRow = () => {
+      if ($container.children.length >= MAX_ITEMS) return;
+      const row = document.createElement("div");
+      row.className = "form-row";
+      row.innerHTML = `
+        <span class="color-chip"></span>
+        <input type="text" class="label" maxlength="30" placeholder="ラベル">
+        <select class="percent">${SELECT_OPTIONS}</select>
+        <button type="button" class="remove-btn">削除</button>
+      `;
+      row.querySelector(".remove-btn").addEventListener("click", () => {
+        $container.removeChild(row);
+        console.log("[entame] remove form");
+        updateAddBtn();
+      });
+      $container.appendChild(row);
+      console.log("[entame] add form");
+      updateAddBtn();
+    };
+
+    /** 追加ボタンの活性状態を更新 */
+    const updateAddBtn = () => {
+      $add.disabled = $container.children.length >= MAX_ITEMS;
+      refreshColors();
+    };
+
+    $add.addEventListener("click", createRow);
+
     $btn.addEventListener("click", () => {
+      const items = Array.from($container.children).map((row, i) => ({
+        label: row.querySelector(".label").value.trim(),
+        percent: Number(row.querySelector(".percent").value),
+        color: COLORS[i]
+      }));
+      console.log(`[entame] generate graph (${items.length} items)`);
       $stage.innerHTML = "";
-      const svg = drawEntameLike(DATA);
+      const svg = drawEntameLike(items);
       $stage.appendChild(svg);
     });
+
+    // 初期表示：フォーム1つ
+    createRow();
   });
 
   /*** 描画メイン ***/

--- a/src/main/resources/static/js/entame-graph.js
+++ b/src/main/resources/static/js/entame-graph.js
@@ -40,6 +40,7 @@
     const $add = document.getElementById("entame-add-btn");
     const $btn = document.getElementById("entame-generate-btn")
               || document.getElementById("entame-generate-btnwo");
+    const $save = document.getElementById("entame-save-btn");
     const $container = document.getElementById("entame-form-container");
     let $stage = document.getElementById("entame-stage");
 
@@ -82,16 +83,33 @@
         $container.removeChild(row);
         console.log("[entame] remove form");
         updateAddBtn();
+        updateGenerateBtn();
       });
+      row.querySelector(".percent").addEventListener("change", updateGenerateBtn);
       $container.appendChild(row);
       console.log("[entame] add form");
       updateAddBtn();
+      updateGenerateBtn();
     };
 
     /** 追加ボタンの活性状態を更新 */
     const updateAddBtn = () => {
       $add.disabled = $container.children.length >= MAX_ITEMS;
       refreshColors();
+    };
+
+    /** 生成ボタンの活性状態を更新（合計が100かチェック） */
+    const updateGenerateBtn = () => {
+      const total = Array.from($container.children)
+        .reduce((sum, row) => sum + Number(row.querySelector(".percent").value), 0);
+      const disabled = total !== 100;
+      $btn.disabled = disabled;
+      console.log(`[entame] total=${total} -> ${disabled ? "disabled" : "enabled"}`);
+    };
+
+    /** 保存ボタンの活性状態を更新 */
+    const updateSaveBtn = () => {
+      if ($save) $save.disabled = !$stage.querySelector("svg");
     };
 
     $add.addEventListener("click", createRow);
@@ -106,10 +124,37 @@
       $stage.innerHTML = "";
       const svg = drawEntameLike(items);
       $stage.appendChild(svg);
+      updateSaveBtn();
     });
+
+    if ($save) {
+      // SVG をPNG画像として保存する
+      $save.addEventListener("click", () => {
+        const svg = $stage.querySelector("svg");
+        if (!svg) return;
+        const serializer = new XMLSerializer();
+        const svgStr = serializer.serializeToString(svg);
+        const canvas = document.createElement("canvas");
+        canvas.width = LAYOUT.W;
+        canvas.height = LAYOUT.H;
+        const ctx = canvas.getContext("2d");
+        const img = new Image();
+        img.onload = () => {
+          ctx.drawImage(img, 0, 0);
+          const a = document.createElement("a");
+          a.href = canvas.toDataURL("image/png");
+          a.download = "entame-graph.png";
+          a.click();
+          console.log("[entame] save image");
+        };
+        img.src = "data:image/svg+xml;charset=utf-8," + encodeURIComponent(svgStr);
+      });
+    }
 
     // 初期表示：フォーム1つ
     createRow();
+    updateGenerateBtn();
+    updateSaveBtn();
   });
 
   /*** 描画メイン ***/

--- a/src/main/resources/templates/entame.html
+++ b/src/main/resources/templates/entame.html
@@ -15,7 +15,8 @@
         <div id="entame-form-container" class="form-container"></div>
         <div class="toolbar">
             <button id="entame-add-btn" type="button">フォーム追加</button>
-            <button id="entame-generate-btn" type="button">円タメグラフ</button>
+            <button id="entame-generate-btn" type="button" disabled>円タメグラフ</button>
+            <button id="entame-save-btn" type="button" disabled>画像保存</button>
         </div>
         <div id="entame-stage" class="entame-stage" aria-live="polite"></div>
     </main>

--- a/src/main/resources/templates/entame.html
+++ b/src/main/resources/templates/entame.html
@@ -12,7 +12,9 @@
     <main class="entame-main">
         <h2>円タメグラフ（画像風SVG）</h2>
         <p class="help">※ ボタンを押すと、TV風の“画像っぽい”レイアウト（SVG）を生成して表示します。</p>
+        <div id="entame-form-container" class="form-container"></div>
         <div class="toolbar">
+            <button id="entame-add-btn" type="button">フォーム追加</button>
             <button id="entame-generate-btn" type="button">円タメグラフ</button>
         </div>
         <div id="entame-stage" class="entame-stage" aria-live="polite"></div>


### PR DESCRIPTION
## 概要
- 円タメグラフのデータをフォームから入力可能にし、最大9件の追加・削除をサポート
- サンプル色を適用するフォームUIとスタイルを追加

## テスト
- `node --check src/main/resources/static/js/entame-graph.js`
- `mvn -q test` : ネットワーク到達不可のため失敗

------
https://chatgpt.com/codex/tasks/task_e_68a48e8092dc832696cc94b673607dea