### PR TITLE
ブラウザJSエラーのサーバ送信機能を追加

### DIFF
--- a/src/main/java/com/github/luluvb0r/nogi_fun_site/web/ClientErrorController.java
+++ b/src/main/java/com/github/luluvb0r/nogi_fun_site/web/ClientErrorController.java
@@ -1,0 +1,74 @@
+package com.github.luluvb0r.nogi_fun_site.web;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * ブラウザから送信されるエラーログを受け取るコントローラ。
+ */
+@RestController
+@RequestMapping("/client-errors")
+public class ClientErrorController {
+
+    private static final Logger log = LoggerFactory.getLogger(ClientErrorController.class);
+
+    /**
+     * クライアント側のログを受信してサーバログへ出力する。
+     *
+     * @param clientLog クライアントログ
+     * @return 204 No Content
+     */
+    @PostMapping
+    public ResponseEntity<Void> receive(@RequestBody(required = false) ClientLog clientLog) {
+        if (clientLog == null) {
+            return ResponseEntity.noContent().build();
+        }
+
+        String message = String.format(
+                "ClientJS [type=%s level=%s] %s at %s:%s:%s url=%s ua=%s",
+                clientLog.type(),
+                clientLog.level(),
+                clientLog.message(),
+                clientLog.filename(),
+                clientLog.lineno(),
+                clientLog.colno(),
+                clientLog.url(),
+                clientLog.userAgent()
+        );
+
+        String stack = clientLog.stack();
+        String logText = stack != null ? message + "\n" + stack : message;
+
+        if ("console".equals(clientLog.type())) {
+            logConsole(clientLog.level(), logText);
+        } else {
+            logError(clientLog.level(), logText);
+        }
+        return ResponseEntity.noContent().build();
+    }
+
+    private void logConsole(String level, String text) {
+        if ("error".equalsIgnoreCase(level)) {
+            log.error(text);
+            return;
+        }
+        if ("warn".equalsIgnoreCase(level)) {
+            log.warn(text);
+            return;
+        }
+        log.info(text);
+    }
+
+    private void logError(String level, String text) {
+        if ("error".equalsIgnoreCase(level)) {
+            log.error(text);
+            return;
+        }
+        log.warn(text);
+    }
+}

--- a/src/main/java/com/github/luluvb0r/nogi_fun_site/web/ClientLog.java
+++ b/src/main/java/com/github/luluvb0r/nogi_fun_site/web/ClientLog.java
@@ -1,0 +1,17 @@
+package com.github.luluvb0r.nogi_fun_site.web;
+
+/**
+ * ブラウザから送信されるクライアントログのDTO。
+ */
+public record ClientLog(
+        String type,
+        String level,
+        String message,
+        String filename,
+        Integer lineno,
+        Integer colno,
+        String stack,
+        String url,
+        String userAgent,
+        String time
+) {}

--- a/src/main/resources/static/js/client-logger.js
+++ b/src/main/resources/static/js/client-logger.js
@@ -1,11 +1,24 @@
+/**
+ * ブラウザで発生した JavaScript エラーやコンソール出力を
+ * サーバへ送信するロガー。
+ */
 (function () {
   'use strict';
 
+  // 送信先エンドポイント
   const ENDPOINT = '/client-errors';
+  // ペイロード全体の最大サイズ (10KB)
   const MAX_PAYLOAD = 10 * 1024; // 10KB
+  // stack プロパティの最大長 (8KB)
   const MAX_STACK = 8 * 1024;    // 8KB
+  // 直近送信時刻の履歴（レート制限用）
   const timestamps = [];
 
+  /**
+   * データを JSON 文字列にし、サイズ超過時は stack をトリミングする。
+   * @param {Object} data 送信対象データ
+   * @returns {string} JSON 文字列
+   */
   function serialize(data) {
     let json = JSON.stringify(data);
     if (json.length > MAX_PAYLOAD && data.stack) {
@@ -15,6 +28,10 @@
     return json;
   }
 
+  /**
+   * Beacon での送信を試み、失敗時は fetch を使ってログを送信する。
+   * @param {Object} data 送信対象データ
+   */
   function send(data) {
     data.time = new Date().toISOString();
     data.url = location.href;
@@ -31,6 +48,10 @@
     });
   }
 
+  /**
+   * 1 秒あたり最大 5 件までに制限してログを送信する。
+   * @param {Object} data 送信対象データ
+   */
   function rateLimitedSend(data) {
     const now = Date.now();
     while (timestamps.length && now - timestamps[0] > 1000) {
@@ -43,6 +64,7 @@
     send(data);
   }
 
+  // window の error イベントを監視して送信
   window.addEventListener('error', function (e) {
     rateLimitedSend({
       type: 'error',
@@ -54,6 +76,7 @@
     });
   });
 
+  // 未処理の Promise rejection を監視して送信
   window.addEventListener('unhandledrejection', function (e) {
     const reason = e.reason;
     let message = '';
@@ -71,6 +94,7 @@
     });
   });
 
+  // console.log / warn / error をラップして送信
   ['log', 'warn', 'error'].forEach(function (level) {
     const original = console[level];
     console[level] = function (...args) {
@@ -83,3 +107,4 @@
     };
   });
 })();
+

--- a/src/main/resources/static/js/client-logger.js
+++ b/src/main/resources/static/js/client-logger.js
@@ -1,0 +1,85 @@
+(function () {
+  'use strict';
+
+  const ENDPOINT = '/client-errors';
+  const MAX_PAYLOAD = 10 * 1024; // 10KB
+  const MAX_STACK = 8 * 1024;    // 8KB
+  const timestamps = [];
+
+  function serialize(data) {
+    let json = JSON.stringify(data);
+    if (json.length > MAX_PAYLOAD && data.stack) {
+      data.stack = data.stack.slice(0, MAX_STACK);
+      json = JSON.stringify(data);
+    }
+    return json;
+  }
+
+  function send(data) {
+    data.time = new Date().toISOString();
+    data.url = location.href;
+    data.userAgent = navigator.userAgent;
+    const json = serialize(data);
+    const blob = new Blob([json], { type: 'application/json' });
+    if (navigator.sendBeacon && navigator.sendBeacon(ENDPOINT, blob)) {
+      return;
+    }
+    fetch(ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: json
+    });
+  }
+
+  function rateLimitedSend(data) {
+    const now = Date.now();
+    while (timestamps.length && now - timestamps[0] > 1000) {
+      timestamps.shift();
+    }
+    if (timestamps.length >= 5) {
+      return;
+    }
+    timestamps.push(now);
+    send(data);
+  }
+
+  window.addEventListener('error', function (e) {
+    rateLimitedSend({
+      type: 'error',
+      message: e.message,
+      filename: e.filename,
+      lineno: e.lineno,
+      colno: e.colno,
+      stack: e.error && e.error.stack || null
+    });
+  });
+
+  window.addEventListener('unhandledrejection', function (e) {
+    const reason = e.reason;
+    let message = '';
+    let stack = null;
+    if (reason instanceof Error) {
+      message = reason.message;
+      stack = reason.stack;
+    } else {
+      message = String(reason);
+    }
+    rateLimitedSend({
+      type: 'unhandledrejection',
+      message: message,
+      stack: stack
+    });
+  });
+
+  ['log', 'warn', 'error'].forEach(function (level) {
+    const original = console[level];
+    console[level] = function (...args) {
+      original.apply(console, args);
+      rateLimitedSend({
+        type: 'console',
+        level: level,
+        message: args.map(a => String(a)).join(' ')
+      });
+    };
+  });
+})();

--- a/src/main/resources/templates/calls.html
+++ b/src/main/resources/templates/calls.html
@@ -6,9 +6,9 @@
     <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
-<header th:replace="fragments/header :: header"></header>
+<header th:replace="~{fragments/header :: header}"></header>
 <div class="container">
-    <aside th:replace="fragments/sidebar :: sidebar"></aside>
+    <aside th:replace="~{fragments/sidebar :: sidebar}"></aside>
     <main>
         <h2>シングル一覧</h2>
         <ul>
@@ -18,6 +18,6 @@
         </ul>
     </main>
 </div>
-<div th:replace="fragments/footer :: footer-scripts"></div>
+<div th:replace="~{fragments/footer :: footer-scripts}"></div>
 </body>
 </html>

--- a/src/main/resources/templates/entame.html
+++ b/src/main/resources/templates/entame.html
@@ -7,9 +7,9 @@
     <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
-<header th:replace="fragments/header :: header"></header>
+<header th:replace="~{fragments/header :: header}"></header>
 <div class="container">
-    <aside th:replace="fragments/sidebar :: sidebar"></aside>
+    <aside th:replace="~{fragments/sidebar :: sidebar}"></aside>
     <main class="entame-main">
         <h2>円タメグラフ（画像風SVG）</h2>
         <p class="help">※ ボタンを押すと、TV風の“画像っぽい”レイアウト（SVG）を生成して表示します。</p>
@@ -22,7 +22,7 @@
         <div id="entame-stage" class="entame-stage" aria-live="polite"></div>
     </main>
 </div>
-<div th:replace="fragments/footer :: footer-scripts"></div>
+<div th:replace="~{fragments/footer :: footer-scripts}"></div>
 <script src="/js/entame-graph.js" defer></script>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -1,3 +1,4 @@
 <th:block xmlns:th="http://www.thymeleaf.org" th:fragment="footer-scripts">
-    <script defer th:src="@{/js/sidebar.js}"></script>
+    <script th:src="@{/js/sidebar.js}" defer></script>
+    <script th:src="@{/js/client-logger.js}" defer></script>
 </th:block>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -6,14 +6,14 @@
     <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
-<header th:replace="fragments/header :: header"></header>
+<header th:replace="~{fragments/header :: header}"></header>
 <div class="container">
-    <aside th:replace="fragments/sidebar :: sidebar"></aside>
+    <aside th:replace="~{fragments/sidebar :: sidebar}"></aside>
     <main>
         <h2>ホーム</h2>
         <p>このサイトでは乃木坂46のライブをより楽しむための情報を提供します。</p>
     </main>
 </div>
-<div th:replace="fragments/footer :: footer-scripts"></div>
+<div th:replace="~{fragments/footer :: footer-scripts}"></div>
 </body>
 </html>

--- a/src/main/resources/templates/song.html
+++ b/src/main/resources/templates/song.html
@@ -6,14 +6,14 @@
     <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
-<header th:replace="fragments/header :: header"></header>
+<header th:replace="~{fragments/header :: header}"></header>
 <div class="container">
-    <aside th:replace="fragments/sidebar :: sidebar"></aside>
+    <aside th:replace="~{fragments/sidebar :: sidebar}"></aside>
     <main>
         <h2 th:text="${song}"></h2>
         <p>このページは曲の詳細情報を表示します。</p>
     </main>
 </div>
-<div th:replace="fragments/footer :: footer-scripts"></div>
+<div th:replace="~{fragments/footer :: footer-scripts}"></div>
 </body>
 </html>

--- a/src/main/resources/templates/songs.html
+++ b/src/main/resources/templates/songs.html
@@ -6,9 +6,9 @@
     <link rel="stylesheet" href="/css/style.css">
 </head>
 <body>
-<header th:replace="fragments/header :: header"></header>
+<header th:replace="~{fragments/header :: header}"></header>
 <div class="container">
-    <aside th:replace="fragments/sidebar :: sidebar"></aside>
+    <aside th:replace="~{fragments/sidebar :: sidebar}"></aside>
     <main>
         <h2 th:text="${single.number} + '枚目シングル ' + ${single.name}"></h2>
         <ul>
@@ -18,6 +18,6 @@
         </ul>
     </main>
 </div>
-<div th:replace="fragments/footer :: footer-scripts"></div>
+<div th:replace="~{fragments/footer :: footer-scripts}"></div>
 </body>
 </html>


### PR DESCRIPTION
## 概要
- ブラウザの error/unhandledrejection/console ログをサーバへ送信する仕組みを実装
- Thymeleaf フラグメントを更新し、全ページでクライアントロガーを読み込み
- フラグメント参照を `~{...}` 構文へ統一

## テスト
- `mvn -q test` (依存取得失敗のため実行不可)


------
https://chatgpt.com/codex/tasks/task_e_68a97b80af248326888f0eb7fd422f01